### PR TITLE
core-icons is not an element

### DIFF
--- a/core-icons.html
+++ b/core-icons.html
@@ -28,7 +28,6 @@ See [core-icon](#core-icon) for more information about working with icons.
 See [core-iconset](#core-iconset) and [core-iconset-svg](#core-iconset-svg) for more information about how to create a custom iconset.
 
 @group Polymer Core Elements
-@element core-icons
 @homepage polymer.github.io
 -->
 <link rel="import" href="../core-icon/core-icon.html">


### PR DESCRIPTION
Documentation had it marked as an element, but its not.
