### PR TITLE
Adds usage information for each icon set.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -81,15 +81,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template is="auto-binding">
     <template repeat="{{iconset in $.meta.metaArray}}">
       <h2>{{iconset.id}}</h2>
-      <h5>{{iconset.id === 'icons' ? 'The Default Set' : 'Import ' + iconset.id + '-icons.html'}}</h5>
-      <small>
-        <template if="{{iconset.id === 'icons'}}">
-          Specified as &lt;core-icon icon="name"&gt;&lt;/core-icon&gt;
-        </template>
-        <template if="{{iconset.id !== 'icons'}}">
-          Specified as &lt;core-icon icon="{{iconset.id}}:name"&gt;&lt;/core-icon&gt;
-        </template>
-      </small>
+      <template if="{{iconset.id === 'icons'}}">
+        <h5>The Default Set</h5>
+        <small>Specified as &lt;core-icon icon="name"&gt;&lt;/core-icon&gt;</small>
+      </template>
+      <template if="{{iconset.id !== 'icons'}}">
+        <h5>Import {{iconset.id}}-icons.html</h5>
+          <small>Specified as &lt;core-icon icon="{{iconset.id}}:name"&gt;&lt;/core-icon&gt;</small>
+      </template>
       <div class="set" horizontal wrap justified layout>
         <template repeat="{{ icon in iconset.iconNames }}">
           <span class="container" vertical center layout>

--- a/demo.html
+++ b/demo.html
@@ -82,6 +82,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <template repeat="{{iconset in $.meta.metaArray}}">
       <h2>{{iconset.id}}</h2>
       <h5>{{iconset.id === 'icons' ? 'The Default Set' : 'Import ' + iconset.id + '-icons.html'}}</h5>
+      <small>
+        <template if="{{iconset.id === 'icons'}}">
+          Specified as &lt;core-icon icon="name"&gt;&lt;/core-icon&gt;
+        </template>
+        <template if="{{iconset.id !== 'icons'}}">
+          Specified as &lt;core-icon icon="{{iconset.id}}:name"&gt;&lt;/core-icon&gt;
+        </template>
+      </small>
       <div class="set" horizontal wrap justified layout>
         <template repeat="{{ icon in iconset.iconNames }}">
           <span class="container" vertical center layout>


### PR DESCRIPTION
This was really frustrating for me because the explanation of usage is in the last sentence of the first section [of this page](https://www.polymer-project.org/docs/elements/icons.html#using-polymers-built-in-icon-sets) and basically nowhere else. This change puts the usage information right on the sheet of example icons so it's easier for newbies to figure it out.
